### PR TITLE
Merging MMLU Pro benchmark results

### DIFF
--- a/projects/llm_eval/eval_mmlupro_api.sh
+++ b/projects/llm_eval/eval_mmlupro_api.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
+# run shell in /llm_eval !
 
-output_dir="./data/eval_results_api/"
 model_name="gpt-4o-mini"
+output_dir="./eval_results_api/$model_name/"
 assigned_subjects="biology"
 batch_size=8
 # export CUDA_VISIBLE_DEVICES=0
 
-python ./eval_mmlupro_api.py \
-                 --output_dir $output_dir \
-                 --model_name $model_name \
-                 --assigned_subjects $assigned_subjects \
-                 --batch_size $batch_size
+python eval_mmlupro_api.py \
+                --output_dir $output_dir \
+                --model_name $model_name \
+                --assigned_subjects $assigned_subjects \
+                --batch_size $batch_size
+
+wait
+
+python merge_summary.py --output_dir $output_dir

--- a/projects/llm_eval/merge_summary.py
+++ b/projects/llm_eval/merge_summary.py
@@ -11,17 +11,25 @@ def merge_output(output_dir):
     for file in outputs:
         if "summary" in file:
             chunk_file = os.path.join(output_dir, file)
-            with open(chunk_file, 'r') as rf:
+            with open(chunk_file, "r") as rf:
                 data = json.load(rf)
                 all_data["total"]["corr"] += data["total"]["corr"]
                 all_data["total"]["wrong"] += data["total"]["wrong"]
-    all_data["total"]["acc"] = all_data["total"]["corr"]/(all_data["total"]["corr"] + all_data["total"]["wrong"])
-    with open(output_file, 'w') as wf:
+    all_data["total"]["acc"] = all_data["total"]["corr"] / (
+        all_data["total"]["corr"] + all_data["total"]["wrong"]
+    )
+    with open(output_file, "w") as wf:
         json.dump(all_data, wf)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--output_dir', type=str, required=True, help='Directory containing the result pickle files.')
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        required=True,
+        help="Directory containing the result pickle files.",
+    )
     args = parser.parse_args()
 
     merge_output(args.output_dir)

--- a/projects/llm_eval/merge_summary.py
+++ b/projects/llm_eval/merge_summary.py
@@ -1,6 +1,7 @@
 import argparse
-import os
 import json
+import os
+
 
 def merge_output(output_dir):
     outputs = os.listdir(output_dir)
@@ -22,5 +23,5 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--output_dir', type=str, required=True, help='Directory containing the result pickle files.')
     args = parser.parse_args()
-    
+
     merge_output(args.output_dir)

--- a/projects/llm_eval/merge_summary.py
+++ b/projects/llm_eval/merge_summary.py
@@ -1,0 +1,26 @@
+import argparse
+import os
+import json
+
+def merge_output(output_dir):
+    outputs = os.listdir(output_dir)
+    output_file = os.path.join(output_dir, "all_subjects_summary.json")
+
+    all_data = {"total": {"corr": 0, "wrong": 0, "acc": 0}}
+    for file in outputs:
+        if "summary" in file:
+            chunk_file = os.path.join(output_dir, file)
+            with open(chunk_file, 'r') as rf:
+                data = json.load(rf)
+                all_data["total"]["corr"] += data["total"]["corr"]
+                all_data["total"]["wrong"] += data["total"]["wrong"]
+    all_data["total"]["acc"] = all_data["total"]["corr"]/(all_data["total"]["corr"] + all_data["total"]["wrong"])
+    with open(output_file, 'w') as wf:
+        json.dump(all_data, wf)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--output_dir', type=str, required=True, help='Directory containing the result pickle files.')
+    args = parser.parse_args()
+    
+    merge_output(args.output_dir)


### PR DESCRIPTION
Summary:
This PR introduces the merging of results from MMLU Pro benchmark into `all_subjects_summary.json` file.
You just have to specify where result.json files are located as the argument of `--output_dir`.
This code was written by @ro-ko and checked by @chanmuzi .

Modified:
- 26th line typo: `merge_output(args.ouput_dir)` -> `merge_output(args.output_dir)`